### PR TITLE
#1 fix remove task bug

### DIFF
--- a/src/daoworks_demo/main.py
+++ b/src/daoworks_demo/main.py
@@ -32,6 +32,7 @@ class TodoApp:
 
     def remove_task(self):
         selected_task = self.task_listbox.get(self.task_listbox.curselection())
+        selected_task = self.displayname_to_taskname(selected_task)
         self.todo_list.remove_task(selected_task)
         self.update_task_listbox()
 


### PR DESCRIPTION
closed #1 
The display name of the task has the words 「（完了）」 and 「（未完了）」, but the task name had to be stripped.